### PR TITLE
feat(dependencies): reltype-aware blocked-state (RFC 9253)

### DIFF
--- a/src/bases/helpers.ts
+++ b/src/bases/helpers.ts
@@ -8,7 +8,7 @@ import { convertInternalToUserProperties } from "../utils/propertyMapping";
 import { DEFAULT_INTERNAL_VISIBLE_PROPERTIES } from "../settings/defaults";
 import type { TaskCardOptions } from "../ui/TaskCard";
 import { PropertyMappingService } from "./PropertyMappingService";
-import { normalizeDependencyList } from "../utils/dependencyUtils";
+import { anyDependencyGatesBlocked, normalizeDependencyList } from "../utils/dependencyUtils";
 import { stringifyUnknown, stringifyUnknownArray } from "../utils/stringUtils";
 import { createTaskNotesLogger } from "../utils/tasknotesLogger";
 
@@ -221,13 +221,13 @@ function createTaskInfoFromProperties(
 	let blockingTasks: string[] = [];
 	let isBlocking = false;
 	if (plugin?.dependencyCache && basesItem.path) {
-		// Use DependencyCache for status-aware blocking check
+		// isBlocked/isBlocking are reltype-gated; the blocking list keeps every dependent.
 		isBlocked = plugin.dependencyCache.isTaskBlocked(basesItem.path);
-		blockingTasks = plugin.dependencyCache.getBlockedTaskPaths(basesItem.path);
-		isBlocking = blockingTasks.length > 0;
+		isBlocking = plugin.dependencyCache.getBlockedTaskPaths(basesItem.path).length > 0;
+		blockingTasks = plugin.dependencyCache.getAllBlockedTaskPaths(basesItem.path);
 	} else {
-		// Fallback when plugin not available: use simple existence check
-		isBlocked = Array.isArray(props.blockedBy) && props.blockedBy.length > 0;
+		// Fallback when the cache is unavailable: existence check, excluding Start-anchored edges.
+		isBlocked = anyDependencyGatesBlocked(props.blockedBy);
 	}
 
 	return {

--- a/src/utils/DependencyCache.ts
+++ b/src/utils/DependencyCache.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion -- Dependency graph traversal guards resolved task nodes before dereferencing. */
 import { TFile, App, Events, EventRef } from "obsidian";
 import { FieldMapper } from "../core/FieldMapper";
-import { normalizeDependencyList, resolveDependencyEntry } from "./dependencyUtils";
+import {
+	normalizeDependencyList,
+	reltypeGatesBlocked,
+	resolveDependencyEntry,
+} from "./dependencyUtils";
+import type { TaskDependencyRelType } from "../types";
 import { TaskNotesSettings } from "../types/settings";
 import { isPathInExcludedFolder, parseExcludedFolders } from "./pathExclusions";
 import { createTaskNotesLogger } from "./tasknotesLogger";
@@ -35,6 +40,8 @@ export class DependencyCache extends Events {
 	private dependencyTargets: Map<string, Set<string>> = new Map(); // task path -> tasks blocked by this task
 	private activeDependencySources: Map<string, Set<string>> = new Map(); // task path -> incomplete blocking task paths
 	private activeDependencyTargets: Map<string, Set<string>> = new Map(); // task path -> tasks actively blocked by this task
+	// dependent path -> blocking path -> parallel edge reltypes; kept so a completion-flip rebuild can re-gate without the original edge
+	private dependencyReltypes: Map<string, Map<string, Set<TaskDependencyRelType>>> = new Map();
 
 	// Project references index
 	private projectReferences: Map<string, Set<string>> = new Map(); // project path -> Set<task paths that reference it>
@@ -188,10 +195,13 @@ export class DependencyCache extends Events {
 	private getFileRelationshipSignature(path: string): string {
 		const blockingTasks = this.sortedSetValues(this.dependencySources.get(path));
 		const blockedTasks = this.sortedSetValues(this.activeDependencyTargets.get(path));
+		// own active blockers: a reltype-only edit (FS->SS) flips blocked-state without changing referenced paths, so the event still fires
+		const activeBlockers = this.sortedSetValues(this.activeDependencySources.get(path));
 		const referencedProjects = this.sortedSetValues(this.projectReferenceSources.get(path));
 		const projectTasks = this.sortedSetValues(this.projectReferences.get(path));
 
 		return JSON.stringify({
+			activeBlockers,
 			blockedTasks,
 			blockingTasks,
 			projectTasks,
@@ -284,15 +294,25 @@ export class DependencyCache extends Events {
 			const normalized = normalizeDependencyList(dependencies);
 			if (normalized) {
 				const blockingTasks = new Set<string>();
+				const reltypesByBlocker = new Map<string, Set<TaskDependencyRelType>>();
 
 				for (const dep of normalized) {
 					const resolved = resolveDependencyEntry(this.app, path, dep);
 					if (resolved?.path && this.isValidFile(resolved.path)) {
-						this.addDependencyLink(path, resolved.path, blockingTasks);
+						let reltypes = reltypesByBlocker.get(resolved.path);
+						if (!reltypes) {
+							reltypes = new Set<TaskDependencyRelType>();
+							reltypesByBlocker.set(resolved.path, reltypes);
+						}
+						reltypes.add(dep.reltype);
 					}
 				}
 
-				if (blockingTasks.size > 0) {
+				if (reltypesByBlocker.size > 0) {
+					this.dependencyReltypes.set(path, reltypesByBlocker);
+					for (const [blockingPath, reltypes] of reltypesByBlocker) {
+						this.addDependencyLink(path, blockingPath, blockingTasks, reltypes);
+					}
 					this.dependencySources.set(path, blockingTasks);
 				}
 			}
@@ -326,7 +346,8 @@ export class DependencyCache extends Events {
 	private addDependencyLink(
 		dependentPath: string,
 		blockingPath: string,
-		blockingTasks: Set<string>
+		blockingTasks: Set<string>,
+		reltypes: Set<TaskDependencyRelType>
 	): void {
 		blockingTasks.add(blockingPath);
 
@@ -335,9 +356,25 @@ export class DependencyCache extends Events {
 		}
 		this.dependencyTargets.get(blockingPath)!.add(dependentPath);
 
-		if (!this.isCompletedPath(blockingPath)) {
+		if (this.anyReltypeGates(reltypes) && !this.isCompletedPath(blockingPath)) {
 			this.addActiveDependencyLink(dependentPath, blockingPath);
 		}
+	}
+
+	private anyReltypeGates(reltypes: Set<TaskDependencyRelType> | undefined): boolean {
+		if (!reltypes || reltypes.size === 0) {
+			return true; // no recorded reltype defaults to Finish-to-Start (gating)
+		}
+		for (const reltype of reltypes) {
+			if (reltypeGatesBlocked(reltype)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private pairGatesBlocked(dependentPath: string, blockingPath: string): boolean {
+		return this.anyReltypeGates(this.dependencyReltypes.get(dependentPath)?.get(blockingPath));
 	}
 
 	private addActiveDependencyLink(dependentPath: string, blockingPath: string): void {
@@ -393,7 +430,9 @@ export class DependencyCache extends Events {
 		}
 
 		for (const dependentPath of blockedTasks) {
-			this.addActiveDependencyLink(dependentPath, blockingPath);
+			if (this.pairGatesBlocked(dependentPath, blockingPath)) {
+				this.addActiveDependencyLink(dependentPath, blockingPath);
+			}
 		}
 	}
 
@@ -402,8 +441,8 @@ export class DependencyCache extends Events {
 		const projectField = this.fieldMapper?.toUserField("projects") || "project";
 
 		const dependencies = (normalizeDependencyList(frontmatter[dependenciesField]) ?? [])
-			.map((dependency) => dependency.uid)
-			.filter((uid) => uid.length > 0)
+			.filter((dependency) => dependency.uid.length > 0)
+			.map((dependency) => `${dependency.uid} ${dependency.reltype}`)
 			.sort();
 		const projects = this.normalizeProjectFingerprintValues(frontmatter[projectField]);
 
@@ -506,6 +545,7 @@ export class DependencyCache extends Events {
 			this.dependencySources.delete(path);
 		}
 		this.activeDependencySources.delete(path);
+		this.dependencyReltypes.delete(path);
 
 		// Also clear project references since those are stored in this task's frontmatter
 		const referencedProjects = this.projectReferenceSources.get(path);
@@ -546,6 +586,7 @@ export class DependencyCache extends Events {
 			this.dependencySources.delete(path);
 		}
 		this.activeDependencySources.delete(path);
+		this.dependencyReltypes.delete(path);
 
 		// Clear from dependency targets
 		const blockedTasks = this.dependencyTargets.get(path);
@@ -557,6 +598,13 @@ export class DependencyCache extends Events {
 					sources.delete(path);
 					if (sources.size === 0) {
 						this.dependencySources.delete(blockedTask);
+					}
+				}
+				const reltypes = this.dependencyReltypes.get(blockedTask);
+				if (reltypes) {
+					reltypes.delete(path);
+					if (reltypes.size === 0) {
+						this.dependencyReltypes.delete(blockedTask);
 					}
 				}
 				this.removeActiveDependencyLink(blockedTask, path);
@@ -635,6 +683,22 @@ export class DependencyCache extends Events {
 		}
 
 		const blocked = this.activeDependencyTargets.get(taskPath);
+		return blocked ? Array.from(blocked) : [];
+	}
+
+	/**
+	 * Every task depending on this one, regardless of reltype, for relationship display — unlike the
+	 * gating getBlockedTaskPaths, this keeps Start-anchored dependents visible. Returns [] when this
+	 * task is completed, matching the gating reverse index so Finish-to-Start-only vaults render identically.
+	 */
+	getAllBlockedTaskPaths(taskPath: string): string[] {
+		if (!this.indexesBuilt) {
+			this.buildIndexesSync();
+		}
+		if (this.isCompletedPath(taskPath)) {
+			return [];
+		}
+		const blocked = this.dependencyTargets.get(taskPath);
 		return blocked ? Array.from(blocked) : [];
 	}
 
@@ -727,6 +791,7 @@ export class DependencyCache extends Events {
 		this.dependencyTargets.clear();
 		this.activeDependencySources.clear();
 		this.activeDependencyTargets.clear();
+		this.dependencyReltypes.clear();
 		this.projectReferences.clear();
 		this.projectReferenceSources.clear();
 		this.relationshipFingerprints.clear();

--- a/src/utils/TaskManager.ts
+++ b/src/utils/TaskManager.ts
@@ -7,6 +7,7 @@ import { TaskNotesSettings } from "../types/settings";
 import type { DependencyCache } from "./DependencyCache";
 import { isPathInExcludedFolder, parseExcludedFolders } from "./pathExclusions";
 import { buildTaskInfoFromMappedTask } from "./taskInfoAssembly";
+import { anyDependencyGatesBlocked } from "./dependencyUtils";
 import { isTaskFrontmatter } from "./taskIdentification";
 import { createTaskNotesLogger } from "./tasknotesLogger";
 
@@ -333,14 +334,16 @@ export class TaskManager extends Events {
 
 			// Get dependency information from DependencyCache
 			let isBlocked = false;
+			let isBlocking = false;
 			let blockingTasks: string[] = [];
 			if (this._dependencyCache) {
-				// Use DependencyCache for status-aware blocking check
+				// isBlocked/isBlocking are reltype-gated; the blocking list keeps every dependent.
 				isBlocked = this._dependencyCache.isTaskBlocked(path);
-				blockingTasks = this._dependencyCache.getBlockedTaskPaths(path);
+				isBlocking = this._dependencyCache.getBlockedTaskPaths(path).length > 0;
+				blockingTasks = this._dependencyCache.getAllBlockedTaskPaths(path);
 			} else {
-				// Fallback when dependency cache not available: use simple existence check
-				isBlocked = Array.isArray(mappedTask.blockedBy) && mappedTask.blockedBy.length > 0;
+				// cache-absent fallback: existence check that still excludes Start-anchored edges
+				isBlocked = anyDependencyGatesBlocked(mappedTask.blockedBy);
 			}
 
 			return buildTaskInfoFromMappedTask({
@@ -348,6 +351,7 @@ export class TaskManager extends Events {
 				mappedTask,
 				defaultTaskStatus: this.settings.defaultTaskStatus,
 				isBlocked,
+				isBlocking,
 				blockingTasks,
 			});
 		} catch (error) {

--- a/src/utils/dependencyUtils.ts
+++ b/src/utils/dependencyUtils.ts
@@ -16,6 +16,11 @@ export function isValidDependencyRelType(value: string): value is TaskDependency
 	return VALID_RELATIONSHIP_TYPES.includes(value as TaskDependencyRelType);
 }
 
+/** Whether a reltype contributes to "blocked" (RFC 9253): Finish-anchored gates, Start-anchored never. Completion is the caller's concern. */
+export function reltypeGatesBlocked(reltype: TaskDependencyRelType): boolean {
+	return reltype === "FINISHTOSTART" || reltype === "FINISHTOFINISH";
+}
+
 export function extractDependencyUid(entry: unknown): string {
 	if (typeof entry === "string") {
 		return entry;
@@ -52,6 +57,12 @@ export function normalizeDependencyEntry(value: unknown): TaskDependency | null 
 	}
 
 	return null;
+}
+
+/** Whether a raw `blockedBy` has any gating (Finish-anchored) edge; a coarse cache-absent fallback that ignores completion. */
+export function anyDependencyGatesBlocked(value: unknown): boolean {
+	const normalized = normalizeDependencyList(value);
+	return normalized ? normalized.some((dependency) => reltypeGatesBlocked(dependency.reltype)) : false;
 }
 
 export function normalizeDependencyList(value: unknown): TaskDependency[] | undefined {

--- a/src/utils/taskInfoAssembly.ts
+++ b/src/utils/taskInfoAssembly.ts
@@ -6,6 +6,7 @@ export interface BuildTaskInfoFromMappedTaskInput {
 	mappedTask: Partial<TaskInfo>;
 	defaultTaskStatus: string;
 	isBlocked: boolean;
+	isBlocking: boolean;
 	blockingTasks: string[];
 }
 
@@ -14,6 +15,7 @@ export function buildTaskInfoFromMappedTask({
 	mappedTask,
 	defaultTaskStatus,
 	isBlocked,
+	isBlocking,
 	blockingTasks,
 }: BuildTaskInfoFromMappedTaskInput): TaskInfo {
 	const totalTrackedTime = mappedTask.timeEntries
@@ -33,7 +35,7 @@ export function buildTaskInfoFromMappedTask({
 		projects: Array.isArray(mappedTask.projects) ? mappedTask.projects : [],
 		totalTrackedTime,
 		isBlocked,
-		isBlocking: blockingTasks.length > 0,
+		isBlocking,
 		blocking: blockingTasks.length > 0 ? blockingTasks : undefined,
 	};
 }

--- a/tests/unit/issues/issue-1100-calendar-filtered-tasks.test.ts
+++ b/tests/unit/issues/issue-1100-calendar-filtered-tasks.test.ts
@@ -58,6 +58,7 @@ function createPlugin(): TaskNotesPlugin {
 		dependencyCache: {
 			isTaskBlocked: jest.fn(() => false),
 			getBlockedTaskPaths: jest.fn(() => []),
+			getAllBlockedTaskPaths: jest.fn(() => []),
 		},
 		app: {
 			metadataCache: {

--- a/tests/unit/utils/DependencyCache.reltype.test.ts
+++ b/tests/unit/utils/DependencyCache.reltype.test.ts
@@ -1,0 +1,221 @@
+import { TFile, type App } from "obsidian";
+import { FieldMapper } from "../../../src/services/FieldMapper";
+import { DEFAULT_FIELD_MAPPING, DEFAULT_SETTINGS } from "../../../src/settings/defaults";
+import {
+	DependencyCache,
+	EVENT_DEPENDENCY_CACHE_CHANGED,
+} from "../../../src/utils/DependencyCache";
+
+type MetadataChangedHandler = (file: TFile, data: unknown, cache: unknown) => void;
+
+type MockApp = App & {
+	__files: Map<string, TFile>;
+	__metadata: Map<string, { frontmatter: Record<string, unknown> }>;
+	__metadataChangedHandlers: MetadataChangedHandler[];
+};
+
+function createMockApp(): MockApp {
+	const files = new Map<string, TFile>();
+	const metadata = new Map<string, { frontmatter: Record<string, unknown> }>();
+	const metadataChangedHandlers: MetadataChangedHandler[] = [];
+
+	const app = {
+		__files: files,
+		__metadata: metadata,
+		__metadataChangedHandlers: metadataChangedHandlers,
+		vault: {
+			getMarkdownFiles: jest.fn(() => Array.from(files.values())),
+			getAbstractFileByPath: jest.fn((path: string) => files.get(path) ?? null),
+			on: jest.fn(() => ({})),
+		},
+		metadataCache: {
+			getFileCache: jest.fn((file: TFile) => metadata.get(file.path) ?? null),
+			getFirstLinkpathDest: jest.fn(
+				(linkpath: string) => files.get(linkpath) ?? files.get(`${linkpath}.md`) ?? null
+			),
+			on: jest.fn((eventName: string, handler: MetadataChangedHandler) => {
+				if (eventName === "changed") {
+					metadataChangedHandlers.push(handler);
+				}
+				return {};
+			}),
+			offref: jest.fn(),
+		},
+	} as unknown as MockApp;
+
+	return app;
+}
+
+function createFile(app: MockApp, path: string, frontmatter: Record<string, unknown>): TFile {
+	const file = new TFile(path);
+	app.__files.set(path, file);
+	app.__metadata.set(path, { frontmatter });
+	return file;
+}
+
+function createDependencyCache(app: MockApp): DependencyCache {
+	return new DependencyCache(
+		app,
+		{ ...DEFAULT_SETTINGS, taskIdentificationMethod: "tag", taskTag: "task" },
+		new FieldMapper(DEFAULT_FIELD_MAPPING),
+		{ isCompletedStatus: jest.fn((status: string) => status === "done") } as never,
+		(frontmatter) => Array.isArray((frontmatter as { tags?: unknown }).tags)
+	);
+}
+
+function invokeMetadataChanged(app: MockApp, path: string): void {
+	const file = app.__files.get(path);
+	if (!file) {
+		throw new Error(`Missing file ${path}`);
+	}
+	const cache = app.__metadata.get(path) ?? null;
+	for (const handler of app.__metadataChangedHandlers) {
+		handler(file, null, cache);
+	}
+}
+
+function blocker(app: MockApp, status = "open"): void {
+	createFile(app, "Tasks/A.md", { title: "A", status, tags: ["task"] });
+}
+
+function dependentWith(app: MockApp, reltype: string, extra: Record<string, unknown>[] = []): void {
+	createFile(app, "Tasks/B.md", {
+		title: "B",
+		status: "open",
+		tags: ["task"],
+		blockedBy: [{ uid: "[[Tasks/A.md]]", reltype }, ...extra],
+	});
+}
+
+describe("DependencyCache reltype-aware blocked-state (RFC 9253)", () => {
+	it("STARTTOSTART does not block (AE7)", async () => {
+		const app = createMockApp();
+		blocker(app);
+		dependentWith(app, "STARTTOSTART");
+		const cache = createDependencyCache(app);
+		cache.initialize();
+		await cache.buildIndexes();
+
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(false);
+		// gating reverse excludes B; display reverse still lists B (existence)
+		expect(cache.getBlockedTaskPaths("Tasks/A.md")).toEqual([]);
+		expect(cache.getAllBlockedTaskPaths("Tasks/A.md")).toEqual(["Tasks/B.md"]);
+	});
+
+	it("STARTTOFINISH does not block", async () => {
+		const app = createMockApp();
+		blocker(app);
+		dependentWith(app, "STARTTOFINISH");
+		const cache = createDependencyCache(app);
+		cache.initialize();
+		await cache.buildIndexes();
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(false);
+	});
+
+	it("FINISHTOSTART blocks while predecessor incomplete (regression)", async () => {
+		const app = createMockApp();
+		blocker(app);
+		dependentWith(app, "FINISHTOSTART");
+		const cache = createDependencyCache(app);
+		cache.initialize();
+		await cache.buildIndexes();
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(true);
+		expect(cache.getBlockedTaskPaths("Tasks/A.md")).toEqual(["Tasks/B.md"]);
+	});
+
+	it("FINISHTOFINISH blocks until predecessor completes", async () => {
+		const app = createMockApp();
+		blocker(app, "open");
+		dependentWith(app, "FINISHTOFINISH");
+		const cache = createDependencyCache(app);
+		cache.initialize();
+		await cache.buildIndexes();
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(true);
+
+		app.__metadata.set("Tasks/A.md", {
+			frontmatter: { title: "A", status: "done", tags: ["task"] },
+		});
+		invokeMetadataChanged(app, "Tasks/A.md");
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(false);
+	});
+
+	it("parallel SS + FS edges to the same predecessor block (any-gates)", async () => {
+		const app = createMockApp();
+		blocker(app);
+		// Two edges B -> A: STARTTOSTART and FINISHTOSTART. The FS edge must gate.
+		dependentWith(app, "STARTTOSTART", [{ uid: "[[Tasks/A.md]]", reltype: "FINISHTOSTART" }]);
+		const cache = createDependencyCache(app);
+		cache.initialize();
+		await cache.buildIndexes();
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(true);
+	});
+
+	it("completed predecessor never gates, for any reltype", async () => {
+		for (const reltype of ["FINISHTOSTART", "FINISHTOFINISH", "STARTTOSTART", "STARTTOFINISH"]) {
+			const app = createMockApp();
+			blocker(app, "done");
+			dependentWith(app, reltype);
+			const cache = createDependencyCache(app);
+			cache.initialize();
+			await cache.buildIndexes();
+			expect(cache.isTaskBlocked("Tasks/B.md")).toBe(false);
+		}
+	});
+
+	it("reltype-only edit FS->SS flips blocked-state AND fires the change event", async () => {
+		const app = createMockApp();
+		blocker(app);
+		dependentWith(app, "FINISHTOSTART");
+		const cache = createDependencyCache(app);
+		const changeHandler = jest.fn();
+		cache.on(EVENT_DEPENDENCY_CACHE_CHANGED, changeHandler);
+		cache.initialize();
+		await cache.buildIndexes();
+		changeHandler.mockClear();
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(true);
+
+		// Drive the real metadata-change path (not a direct indexTaskFile call).
+		app.__metadata.set("Tasks/B.md", {
+			frontmatter: {
+				title: "B",
+				status: "open",
+				tags: ["task"],
+				blockedBy: [{ uid: "[[Tasks/A.md]]", reltype: "STARTTOSTART" }],
+			},
+		});
+		invokeMetadataChanged(app, "Tasks/B.md");
+
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(false);
+		expect(changeHandler).toHaveBeenCalled();
+	});
+
+	it("display split: SS-only predecessor is not gating-blocking but still lists its dependent", async () => {
+		const app = createMockApp();
+		blocker(app);
+		dependentWith(app, "STARTTOSTART");
+		const cache = createDependencyCache(app);
+		cache.initialize();
+		await cache.buildIndexes();
+
+		expect(cache.getBlockedTaskPaths("Tasks/A.md")).toEqual([]); // gating (narrow)
+		expect(cache.getAllBlockedTaskPaths("Tasks/A.md")).toEqual(["Tasks/B.md"]); // display (complete)
+	});
+
+	it("FS-only vault: display reverse matches gating reverse and clears on completion", async () => {
+		const app = createMockApp();
+		blocker(app);
+		dependentWith(app, "FINISHTOSTART");
+		const cache = createDependencyCache(app);
+		cache.initialize();
+		await cache.buildIndexes();
+
+		expect(cache.getAllBlockedTaskPaths("Tasks/A.md")).toEqual(["Tasks/B.md"]);
+
+		app.__metadata.set("Tasks/A.md", {
+			frontmatter: { title: "A", status: "done", tags: ["task"] },
+		});
+		invokeMetadataChanged(app, "Tasks/A.md");
+		// A completed -> display reverse clears too (byte-identical to legacy active reverse)
+		expect(cache.getAllBlockedTaskPaths("Tasks/A.md")).toEqual([]);
+	});
+});

--- a/tests/unit/utils/DependencyCache.reltype.test.ts
+++ b/tests/unit/utils/DependencyCache.reltype.test.ts
@@ -8,21 +8,26 @@ import {
 
 type MetadataChangedHandler = (file: TFile, data: unknown, cache: unknown) => void;
 
+type MetadataDeletedHandler = (file: TFile, prevCache: unknown) => void;
+
 type MockApp = App & {
 	__files: Map<string, TFile>;
 	__metadata: Map<string, { frontmatter: Record<string, unknown> }>;
 	__metadataChangedHandlers: MetadataChangedHandler[];
+	__metadataDeletedHandlers: MetadataDeletedHandler[];
 };
 
 function createMockApp(): MockApp {
 	const files = new Map<string, TFile>();
 	const metadata = new Map<string, { frontmatter: Record<string, unknown> }>();
 	const metadataChangedHandlers: MetadataChangedHandler[] = [];
+	const metadataDeletedHandlers: MetadataDeletedHandler[] = [];
 
 	const app = {
 		__files: files,
 		__metadata: metadata,
 		__metadataChangedHandlers: metadataChangedHandlers,
+		__metadataDeletedHandlers: metadataDeletedHandlers,
 		vault: {
 			getMarkdownFiles: jest.fn(() => Array.from(files.values())),
 			getAbstractFileByPath: jest.fn((path: string) => files.get(path) ?? null),
@@ -33,9 +38,11 @@ function createMockApp(): MockApp {
 			getFirstLinkpathDest: jest.fn(
 				(linkpath: string) => files.get(linkpath) ?? files.get(`${linkpath}.md`) ?? null
 			),
-			on: jest.fn((eventName: string, handler: MetadataChangedHandler) => {
+			on: jest.fn((eventName: string, handler: MetadataChangedHandler | MetadataDeletedHandler) => {
 				if (eventName === "changed") {
-					metadataChangedHandlers.push(handler);
+					metadataChangedHandlers.push(handler as MetadataChangedHandler);
+				} else if (eventName === "deleted") {
+					metadataDeletedHandlers.push(handler as MetadataDeletedHandler);
 				}
 				return {};
 			}),
@@ -72,6 +79,24 @@ function invokeMetadataChanged(app: MockApp, path: string): void {
 	for (const handler of app.__metadataChangedHandlers) {
 		handler(file, null, cache);
 	}
+}
+
+function invokeMetadataDeleted(app: MockApp, path: string): void {
+	const file = app.__files.get(path);
+	if (!file) {
+		throw new Error(`Missing file ${path}`);
+	}
+	app.__files.delete(path);
+	app.__metadata.delete(path);
+	for (const handler of app.__metadataDeletedHandlers) {
+		handler(file, null);
+	}
+}
+
+function setStatus(app: MockApp, path: string, status: string): void {
+	const current = app.__metadata.get(path)?.frontmatter ?? {};
+	app.__metadata.set(path, { frontmatter: { ...current, status } });
+	invokeMetadataChanged(app, path);
 }
 
 function blocker(app: MockApp, status = "open"): void {
@@ -216,6 +241,71 @@ describe("DependencyCache reltype-aware blocked-state (RFC 9253)", () => {
 		});
 		invokeMetadataChanged(app, "Tasks/A.md");
 		// A completed -> display reverse clears too (byte-identical to legacy active reverse)
+		expect(cache.getAllBlockedTaskPaths("Tasks/A.md")).toEqual([]);
+	});
+
+	it("un-completion (done->open) re-gates by reltype: SS stays unblocked, FS/FF re-block", async () => {
+		// The rebuild re-add branch only runs on done->open; it must consult reltype.
+		const ss = createMockApp();
+		blocker(ss, "done");
+		dependentWith(ss, "STARTTOSTART");
+		const ssCache = createDependencyCache(ss);
+		ssCache.initialize();
+		await ssCache.buildIndexes();
+		expect(ssCache.isTaskBlocked("Tasks/B.md")).toBe(false);
+		setStatus(ss, "Tasks/A.md", "open");
+		expect(ssCache.isTaskBlocked("Tasks/B.md")).toBe(false);
+
+		for (const reltype of ["FINISHTOSTART", "FINISHTOFINISH"]) {
+			const app = createMockApp();
+			blocker(app, "done");
+			dependentWith(app, reltype);
+			const cache = createDependencyCache(app);
+			cache.initialize();
+			await cache.buildIndexes();
+			expect(cache.isTaskBlocked("Tasks/B.md")).toBe(false);
+			setStatus(app, "Tasks/A.md", "open");
+			expect(cache.isTaskBlocked("Tasks/B.md")).toBe(true);
+		}
+	});
+
+	it("edges to different predecessors gate independently", async () => {
+		const app = createMockApp();
+		createFile(app, "Tasks/A.md", { title: "A", status: "open", tags: ["task"] });
+		createFile(app, "Tasks/C.md", { title: "C", status: "open", tags: ["task"] });
+		createFile(app, "Tasks/B.md", {
+			title: "B",
+			status: "open",
+			tags: ["task"],
+			blockedBy: [
+				{ uid: "[[Tasks/A.md]]", reltype: "STARTTOSTART" },
+				{ uid: "[[Tasks/C.md]]", reltype: "FINISHTOSTART" },
+			],
+		});
+		const cache = createDependencyCache(app);
+		cache.initialize();
+		await cache.buildIndexes();
+
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(true); // C (FS) gates
+		expect(cache.getBlockedTaskPaths("Tasks/A.md")).toEqual([]); // SS never gates
+		expect(cache.getBlockedTaskPaths("Tasks/C.md")).toEqual(["Tasks/B.md"]);
+		expect(cache.getAllBlockedTaskPaths("Tasks/A.md")).toEqual(["Tasks/B.md"]); // display
+
+		setStatus(app, "Tasks/C.md", "done");
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(false); // A's SS edge never gated
+	});
+
+	it("deleting a blocker clears its gate and reltype entry", async () => {
+		const app = createMockApp();
+		blocker(app);
+		dependentWith(app, "STARTTOSTART", [{ uid: "[[Tasks/A.md]]", reltype: "FINISHTOSTART" }]);
+		const cache = createDependencyCache(app);
+		cache.initialize();
+		await cache.buildIndexes();
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(true);
+
+		invokeMetadataDeleted(app, "Tasks/A.md");
+		expect(cache.isTaskBlocked("Tasks/B.md")).toBe(false);
 		expect(cache.getAllBlockedTaskPaths("Tasks/A.md")).toEqual([]);
 	});
 });

--- a/tests/unit/utils/dependencyUtils.gating.test.ts
+++ b/tests/unit/utils/dependencyUtils.gating.test.ts
@@ -1,0 +1,46 @@
+import { anyDependencyGatesBlocked, reltypeGatesBlocked } from "../../../src/utils/dependencyUtils";
+
+describe("reltypeGatesBlocked", () => {
+	it("gates for Finish-anchored reltypes only", () => {
+		expect(reltypeGatesBlocked("FINISHTOSTART")).toBe(true);
+		expect(reltypeGatesBlocked("FINISHTOFINISH")).toBe(true);
+		expect(reltypeGatesBlocked("STARTTOSTART")).toBe(false);
+		expect(reltypeGatesBlocked("STARTTOFINISH")).toBe(false);
+	});
+});
+
+describe("anyDependencyGatesBlocked (cache-absent fallback)", () => {
+	it("returns false for empty/absent values", () => {
+		expect(anyDependencyGatesBlocked(undefined)).toBe(false);
+		expect(anyDependencyGatesBlocked(null)).toBe(false);
+		expect(anyDependencyGatesBlocked([])).toBe(false);
+	});
+
+	it("treats a legacy bare-string entry as Finish-to-Start (gates)", () => {
+		expect(anyDependencyGatesBlocked(["[[A]]"])).toBe(true);
+		expect(anyDependencyGatesBlocked("[[A]]")).toBe(true);
+	});
+
+	it("excludes Start-anchored edges", () => {
+		expect(anyDependencyGatesBlocked([{ uid: "[[A]]", reltype: "STARTTOSTART" }])).toBe(false);
+		expect(anyDependencyGatesBlocked([{ uid: "[[A]]", reltype: "STARTTOFINISH" }])).toBe(false);
+	});
+
+	it("gates for Finish-anchored edges", () => {
+		expect(anyDependencyGatesBlocked([{ uid: "[[A]]", reltype: "FINISHTOSTART" }])).toBe(true);
+		expect(anyDependencyGatesBlocked([{ uid: "[[A]]", reltype: "FINISHTOFINISH" }])).toBe(true);
+	});
+
+	it("gates when any edge in a mixed list gates", () => {
+		expect(
+			anyDependencyGatesBlocked([
+				{ uid: "[[A]]", reltype: "STARTTOSTART" },
+				{ uid: "[[B]]", reltype: "FINISHTOSTART" },
+			])
+		).toBe(true);
+	});
+
+	it("does not throw on a single non-array object entry", () => {
+		expect(anyDependencyGatesBlocked({ uid: "[[A]]", reltype: "STARTTOSTART" })).toBe(false);
+	});
+});

--- a/tests/unit/utils/taskInfoAssembly.test.ts
+++ b/tests/unit/utils/taskInfoAssembly.test.ts
@@ -23,6 +23,7 @@ describe("buildTaskInfoFromMappedTask", () => {
 			mappedTask: makeTask({ id: "old-id", path: "Mapped/original.md" }),
 			defaultTaskStatus: "open",
 			isBlocked: true,
+			isBlocking: true,
 			blockingTasks: ["Tasks/dependent.md"],
 		});
 
@@ -33,6 +34,20 @@ describe("buildTaskInfoFromMappedTask", () => {
 			isBlocking: true,
 			blocking: ["Tasks/dependent.md"],
 		});
+	});
+
+	it("keeps a non-gating dependent in the blocking list while isBlocking stays false", () => {
+		const task = buildTaskInfoFromMappedTask({
+			path: "Tasks/predecessor.md",
+			mappedTask: makeTask(),
+			defaultTaskStatus: "open",
+			isBlocked: false,
+			isBlocking: false,
+			blockingTasks: ["Tasks/start-anchored-dependent.md"],
+		});
+
+		expect(task.isBlocking).toBe(false);
+		expect(task.blocking).toEqual(["Tasks/start-anchored-dependent.md"]);
 	});
 
 	it("defaults missing display fields and list fields", () => {
@@ -48,6 +63,7 @@ describe("buildTaskInfoFromMappedTask", () => {
 			}),
 			defaultTaskStatus: "todo",
 			isBlocked: false,
+			isBlocking: false,
 			blockingTasks: [],
 		});
 
@@ -82,6 +98,7 @@ describe("buildTaskInfoFromMappedTask", () => {
 			}),
 			defaultTaskStatus: "open",
 			isBlocked: false,
+			isBlocking: false,
 			blockingTasks: [],
 		});
 


### PR DESCRIPTION
## Summary

Makes TaskNotes' dependency blocked-state honor each `blockedBy` edge's RFC 9253 `reltype` instead of treating every edge as a hard Finish-to-Start block. The data model already stored `{uid, reltype, gap?}` and round-tripped it through frontmatter and the HTTP API, but the value was behaviorally inert — `DependencyCache` discarded it at index time. This change makes it load-bearing.

This is the first of three focused PRs adding RFC 9253 dependency-type support (blocked-state → display fidelity → authoring UI). It unblocks the companion Gantt plugin, which already reads/writes all four reltypes but stalled because TaskNotes marked Start-anchored dependents as "blocked."

## Behavior

| reltype | predecessor incomplete | predecessor complete |
|---|---|---|
| `FINISHTOSTART` | gates (blocked) | does not gate |
| `FINISHTOFINISH` | gates (blocked) | does not gate |
| `STARTTOSTART` | does not gate | does not gate |
| `STARTTOFINISH` | does not gate | does not gate |

A dependent with parallel edges to one predecessor is blocked if **any** edge gates. A completed predecessor never gates, for any reltype (unchanged).

## What changed

- **`DependencyCache`** stores per-pair reltypes so a completion-flip rebuild can re-gate, and reltype now participates in both the re-index fingerprint and the change-event signature, so a reltype-only edit re-indexes **and** fires `EVENT_DEPENDENCY_CACHE_CHANGED`.
- **`taskInfoAssembly`** seam split: `isBlocking` narrows to gating edges (so the `dependencies.isBlocking` filter and blocked badges are reltype-accurate), while the `blocking` display list keeps every dependent via a new completion-filtered `getAllBlockedTaskPaths`, so no relationship disappears from a card.
- **Cache-absent fallbacks** (TaskManager, Bases) exclude Start-anchored edges via a shared `reltypeGatesBlocked` helper.

## Compatibility

Finish-to-Start-only vaults are **unchanged** — the existing `DependencyCache.optimization` and `issue-1878` regression tests stay green untouched. Vaults that already contain non-FS edges (created via the Gantt/HTTP API) will correctly **stop** showing Start-anchored dependents as blocked — the intended fix, but a visible change worth noting.

## Tests

New `DependencyCache.reltype` battery + `dependencyUtils.gating` covering: SS/SF don't block, FF blocks until the predecessor completes, parallel any-gates aggregation, un-completion re-gating, reltype-only-edit fires the change event, the isBlocking/blocking display split, cache-absent fallback shapes, and edges to different predecessors. Full unit suite: 3888 passing. (Seven pre-existing date/timezone-sensitive suites fail identically on `main` and are unrelated to this change.)

## Residual Review Findings

- **P3 (deferred to the display follow-up):** After broadening the `blocking` display list to include Start-anchored dependents, the task-card "Blocking (N)" pill (gated on `isBlocking`) and the secondary-badge toggle (keyed on `blocking.length`) can diverge for a Start-anchored-only predecessor. Cosmetic and confined to non-FS vaults; harmonizing those surfaces (with reltype badges) belongs to the read-fidelity change that follows.
