### PR TITLE
feat(dependencies): reltype/gap badge on blocked-by task cards

### DIFF
--- a/src/ui/taskCardProperties.ts
+++ b/src/ui/taskCardProperties.ts
@@ -33,7 +33,11 @@ import {
 	type LinkServices,
 } from "./renderers/linkRenderer";
 import { renderContextsValue, renderTagsValue, type TagServices } from "./renderers/tagRenderer";
-import { normalizeDependencyEntry, resolveDependencyEntry } from "../utils/dependencyUtils";
+import {
+	formatDependencyBadge,
+	normalizeDependencyEntry,
+	resolveDependencyEntry,
+} from "../utils/dependencyUtils";
 import { createTaskNotesLogger } from "../utils/tasknotesLogger";
 
 const tasknotesLogger = createTaskNotesLogger({ tag: "Ui/TaskCardProperties" });
@@ -463,6 +467,20 @@ const PROPERTY_RENDERERS: Record<string, PropertyRenderer> = {
 						dependencyLink.displayText,
 						linkServices
 					);
+					const normalized = normalizeDependencyEntry(dep);
+					const badge = normalized ? formatDependencyBadge(normalized) : null;
+					if (badge && normalized) {
+						const badgeEl = linksContainer.createEl("span", {
+							cls: "task-card__dependency-badge",
+							text: badge,
+						});
+						setTooltip(
+							badgeEl,
+							normalized.gap
+								? `${normalized.reltype} (gap ${normalized.gap})`
+								: normalized.reltype
+						);
+					}
 				}
 			});
 		}

--- a/src/utils/dependencyUtils.ts
+++ b/src/utils/dependencyUtils.ts
@@ -16,6 +16,35 @@ export function isValidDependencyRelType(value: string): value is TaskDependency
 	return VALID_RELATIONSHIP_TYPES.includes(value as TaskDependencyRelType);
 }
 
+const RELTYPE_SHORT_LABEL: Record<TaskDependencyRelType, string> = {
+	FINISHTOSTART: "FS",
+	FINISHTOFINISH: "FF",
+	STARTTOSTART: "SS",
+	STARTTOFINISH: "SF",
+};
+
+/** Short RFC 9253 code for a reltype, e.g. "SS" — for compact relationship badges. */
+export function reltypeShortLabel(reltype: TaskDependencyRelType): string {
+	return RELTYPE_SHORT_LABEL[reltype] ?? RELTYPE_SHORT_LABEL[DEFAULT_DEPENDENCY_RELTYPE];
+}
+
+/**
+ * Compact display badge for a dependency edge, or null when it is the plain default
+ * (Finish-to-Start with no gap) — so common Finish-to-Start-only vaults show no chrome.
+ * Non-default edges render the reltype code and, when set, the gap: "SS", "FF · P1D", "FS · P2D".
+ */
+export function formatDependencyBadge(dependency: TaskDependency): string | null {
+	const gap = dependency.gap?.trim();
+	if (dependency.reltype === DEFAULT_DEPENDENCY_RELTYPE && !gap) {
+		return null;
+	}
+	const parts = [reltypeShortLabel(dependency.reltype)];
+	if (gap) {
+		parts.push(gap);
+	}
+	return parts.join(" · ");
+}
+
 /** Whether a reltype contributes to "blocked" (RFC 9253): Finish-anchored gates, Start-anchored never. Completion is the caller's concern. */
 export function reltypeGatesBlocked(reltype: TaskDependencyRelType): boolean {
 	return reltype === "FINISHTOSTART" || reltype === "FINISHTOFINISH";

--- a/styles/task-card-bem.css
+++ b/styles/task-card-bem.css
@@ -207,6 +207,17 @@
     border-color: color-mix(in srgb, var(--tn-color-error) 70%, transparent);
 }
 
+.tasknotes-plugin .task-card__dependency-badge {
+    margin-inline-start: var(--tn-spacing-xs);
+    padding-inline: var(--tn-spacing-xs);
+    border-radius: var(--tn-radius-sm);
+    background: var(--tn-bg-secondary);
+    color: var(--tn-text-muted);
+    font-size: var(--tn-font-size-xs);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
 .tasknotes-plugin .task-card__metadata-pill--google-calendar {
     background: transparent;
     color: var(--tn-color-google-calendar);

--- a/tests/unit/utils/dependencyUtils.badge.test.ts
+++ b/tests/unit/utils/dependencyUtils.badge.test.ts
@@ -1,0 +1,39 @@
+import { formatDependencyBadge, reltypeShortLabel } from "../../../src/utils/dependencyUtils";
+import type { TaskDependency } from "../../../src/types";
+
+function dep(reltype: TaskDependency["reltype"], gap?: string): TaskDependency {
+	return gap ? { uid: "A", reltype, gap } : { uid: "A", reltype };
+}
+
+describe("reltypeShortLabel", () => {
+	it("maps each reltype to its RFC code", () => {
+		expect(reltypeShortLabel("FINISHTOSTART")).toBe("FS");
+		expect(reltypeShortLabel("FINISHTOFINISH")).toBe("FF");
+		expect(reltypeShortLabel("STARTTOSTART")).toBe("SS");
+		expect(reltypeShortLabel("STARTTOFINISH")).toBe("SF");
+	});
+});
+
+describe("formatDependencyBadge", () => {
+	it("returns null for the plain default (Finish-to-Start, no gap) — no chrome", () => {
+		expect(formatDependencyBadge(dep("FINISHTOSTART"))).toBeNull();
+	});
+
+	it("shows the gap for a Finish-to-Start edge that has one", () => {
+		expect(formatDependencyBadge(dep("FINISHTOSTART", "P2D"))).toBe("FS · P2D");
+	});
+
+	it("shows the reltype code for non-default edges", () => {
+		expect(formatDependencyBadge(dep("STARTTOSTART"))).toBe("SS");
+		expect(formatDependencyBadge(dep("STARTTOFINISH"))).toBe("SF");
+	});
+
+	it("shows reltype and gap together", () => {
+		expect(formatDependencyBadge(dep("FINISHTOFINISH", "P1D"))).toBe("FF · P1D");
+		expect(formatDependencyBadge(dep("STARTTOSTART", "P1W"))).toBe("SS · P1W");
+	});
+
+	it("ignores a blank gap", () => {
+		expect(formatDependencyBadge(dep("FINISHTOSTART", "   "))).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Second of the RFC 9253 dependency-type PRs (after reltype-aware blocked-state). Now that a `blockedBy` edge can carry a non-Finish-to-Start `reltype` (or a `gap`), the task card shows it: a compact badge renders after each "Blocked by:" link so the dependency's true meaning is visible without opening the note or the Gantt.

## What changed

- **`formatDependencyBadge(dep)`** / **`reltypeShortLabel(reltype)`** in `dependencyUtils` — a compact badge string, or `null` for the plain default (Finish-to-Start, no gap):
  - `STARTTOSTART` → `SS`
  - `FINISHTOFINISH` with `gap: P1D` → `FF · P1D`
  - `FINISHTOSTART` with `gap: P2D` → `FS · P2D`
  - `FINISHTOSTART` with no gap → **no badge**
- The `blockedBy` card renderer appends the badge (with a `reltype`/`gap` tooltip) after each dependency link.
- A muted, tabular-nums `.task-card__dependency-badge` style.

## Compatibility

Finish-to-Start-only vaults render identically — the badge is suppressed for the plain default, so no new chrome appears unless an edge is actually non-FS or has a gap.

## Scope / follow-ups

Deliberately scoped to the **blocked-by (forward) card** where `reltype`/`gap` are directly on `task.blockedBy`. Deferred:
- **Reverse-direction badge** (a predecessor's "Blocking:" list) — `task.blocking` is paths-only, so it needs a small cache accessor to surface each dependent's reltype.
- **Modal-row display** — folded into the authoring-row change that follows (avoids editing the same rows twice).
- **Blocking pill / secondary-badge harmonization** for Start-anchored-only predecessors (the residual noted on the blocked-state PR).

## Tests

`dependencyUtils.badge` unit tests cover every reltype, gap/no-gap, blank-gap, and the FS-no-gap null case. Card + dependency suites: 191 passing, no regressions. (Visual badge rendering verified manually; the DOM append is a thin wrapper over the tested helper.)
