### PR TITLE
feat(dependencies): opt-in reltype selector for authoring RFC 9253 types

### DIFF
--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -980,6 +980,15 @@ export const en: TranslationTree = {
 						"Generate markdown links ([text](path)) instead of wikilinks ([[link]]) in frontmatter properties.\n\n⚠️ Requires the 'obsidian-frontmatter-markdown-links' plugin to work correctly.",
 				},
 			},
+			dependencies: {
+				header: "Dependencies",
+				description: "Configure task dependency relationships.",
+				advancedTypes: {
+					name: "Enable advanced dependency types",
+					description:
+						"Show a relationship-type selector on the blocked-by list in the task modal so you can author finish → finish, start → start, and start → finish dependencies, not just the default finish → start. Only finish-anchored types mark a task as blocked.",
+				},
+			},
 			taskInteraction: {
 				header: "Task interaction",
 				description: "Configure how clicking on tasks behaves.",
@@ -2631,6 +2640,13 @@ export const en: TranslationTree = {
 				addTaskButton: "Add task",
 				selectTaskTooltip: "Select a task note using fuzzy search",
 				removeTaskTooltip: "Remove task",
+				reltypeLabel: "Type",
+				reltype: {
+					finishToStart: "Finish → start",
+					finishToFinish: "Finish → finish",
+					startToStart: "Start → start",
+					startToFinish: "Start → finish",
+				},
 			},
 			organization: {
 				projects: "Projects",

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -16,7 +16,7 @@ import {
 } from "./taskModalDetailsEditor";
 import { splitFrontmatterAndBody } from "../utils/helpers";
 import { ProjectSelectModal } from "./ProjectSelectModal";
-import { TaskDependency, Reminder } from "../types";
+import { TaskDependency, TaskDependencyRelType, Reminder } from "../types";
 import { DEFAULT_DEPENDENCY_RELTYPE, formatDependencyLink } from "../utils/dependencyUtils";
 import { type LinkServices } from "../ui/renderers/linkRenderer";
 import { generateLink } from "../utils/linkUtils";
@@ -182,10 +182,23 @@ export abstract class TaskModal extends Modal {
 	}
 
 	protected renderBlockedByList(): void {
-		void this.renderDependencyList(this.blockedByList, this.blockedByItems, (index) => {
-			this.blockedByItems = removeDependencyItemAtIndex(this.blockedByItems, index);
-			this.renderBlockedByList();
-		});
+		void this.renderDependencyList(
+			this.blockedByList,
+			this.blockedByItems,
+			(index) => {
+				this.blockedByItems = removeDependencyItemAtIndex(this.blockedByItems, index);
+				this.renderBlockedByList();
+			},
+			{
+				showReltypeControls: this.plugin.settings.enableAdvancedDependencyTypes,
+				onReltypeChange: (index, reltype) => {
+					const item = this.blockedByItems[index];
+					if (item) {
+						item.dependency = { ...item.dependency, reltype };
+					}
+				},
+			}
+		);
 	}
 
 	protected renderBlockingList(): void {
@@ -198,7 +211,11 @@ export abstract class TaskModal extends Modal {
 	private async renderDependencyList(
 		listEl: HTMLElement | undefined,
 		items: DependencyItem[],
-		onRemove: (index: number) => void
+		onRemove: (index: number) => void,
+		reltypeControls?: {
+			showReltypeControls: boolean;
+			onReltypeChange: (index: number, reltype: TaskDependencyRelType) => void;
+		}
 	): Promise<void> {
 		if (!listEl) {
 			return;
@@ -211,6 +228,8 @@ export abstract class TaskModal extends Modal {
 			linkServices: this.getLinkServices(),
 			translate: (key, params) => this.t(key, params),
 			onRemove,
+			showReltypeControls: reltypeControls?.showReltypeControls,
+			onReltypeChange: reltypeControls?.onReltypeChange,
 		});
 	}
 

--- a/src/modals/taskModalDependencies.ts
+++ b/src/modals/taskModalDependencies.ts
@@ -1,6 +1,6 @@
 import { setTooltip, TFile } from "obsidian";
 import TaskNotesPlugin from "../main";
-import { TaskDependency, TaskInfo } from "../types";
+import { TaskDependency, TaskDependencyRelType, TaskInfo } from "../types";
 import {
 	DEFAULT_DEPENDENCY_RELTYPE,
 	formatDependencyLink,
@@ -30,7 +30,16 @@ export interface RenderDependencyListOptions {
 	linkServices: LinkServices;
 	translate: (key: string, params?: Record<string, string | number>) => string;
 	onRemove: (index: number) => void;
+	showReltypeControls?: boolean;
+	onReltypeChange?: (index: number, reltype: TaskDependencyRelType) => void;
 }
+
+const RELTYPE_OPTION_KEYS: ReadonlyArray<[TaskDependencyRelType, string]> = [
+	["FINISHTOSTART", "finishToStart"],
+	["FINISHTOFINISH", "finishToFinish"],
+	["STARTTOSTART", "startToStart"],
+	["STARTTOFINISH", "startToFinish"],
+];
 
 export function createDependencyItemFromFile(
 	{ plugin, sourcePath }: CreateDependencyContext,
@@ -153,6 +162,8 @@ export async function renderDependencyList({
 	linkServices,
 	translate,
 	onRemove,
+	showReltypeControls,
+	onReltypeChange,
 }: RenderDependencyListOptions): Promise<void> {
 	if (!listEl) {
 		return;
@@ -191,6 +202,10 @@ export async function renderDependencyList({
 			renderUnresolvedDependency(contentEl, item);
 		}
 
+		if (showReltypeControls && onReltypeChange) {
+			renderReltypeSelect(itemEl, item, index, translate, onReltypeChange);
+		}
+
 		const removeBtn = itemEl.createEl("button", {
 			cls: "task-project-remove",
 			text: "×",
@@ -204,6 +219,29 @@ export async function renderDependencyList({
 			onRemove(index);
 		});
 	}
+}
+
+function renderReltypeSelect(
+	itemEl: HTMLElement,
+	item: DependencyItem,
+	index: number,
+	translate: (key: string, params?: Record<string, string | number>) => string,
+	onReltypeChange: (index: number, reltype: TaskDependencyRelType) => void
+): void {
+	const label = translate("modals.task.dependencies.reltypeLabel");
+	const select = itemEl.createEl("select", { cls: "task-project-item__reltype" });
+	select.setAttribute("aria-label", label);
+	setTooltip(select, label, { placement: "top" });
+	for (const [value, key] of RELTYPE_OPTION_KEYS) {
+		const option = select.createEl("option", {
+			value,
+			text: translate(`modals.task.dependencies.reltype.${key}`),
+		});
+		option.selected = item.dependency.reltype === value;
+	}
+	select.addEventListener("change", () => {
+		onReltypeChange(index, select.value as TaskDependencyRelType);
+	});
 }
 
 async function renderResolvedDependency(

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -397,6 +397,7 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	resetCheckboxesOnRecurrence: false, // Off by default - user opts in
 	// Frontmatter link format defaults
 	useFrontmatterMarkdownLinks: false, // Default to wikilinks for compatibility
+	enableAdvancedDependencyTypes: false, // Opt-in: authoring of non-Finish-to-Start dependency types
 	// OAuth Calendar Integration defaults
 	googleOAuthClientId: "",
 	googleOAuthClientSecret: "",

--- a/src/settings/tabs/generalTab.ts
+++ b/src/settings/tabs/generalTab.ts
@@ -683,6 +683,29 @@ export function renderGeneralTab(
 		);
 	}
 
+	// Dependencies Section
+	createSettingGroup(
+		container,
+		{
+			heading: translate("settings.general.dependencies.header"),
+			description: translate("settings.general.dependencies.description"),
+		},
+		(group) => {
+			group.addSetting(
+				(setting) =>
+					void configureToggleSetting(setting, {
+						name: translate("settings.general.dependencies.advancedTypes.name"),
+						desc: translate("settings.general.dependencies.advancedTypes.description"),
+						getValue: () => plugin.settings.enableAdvancedDependencyTypes,
+						setValue: async (value: boolean) => {
+							plugin.settings.enableAdvancedDependencyTypes = value;
+							save();
+						},
+					})
+			);
+		}
+	);
+
 	// Release Notes Section
 	createSettingGroup(
 		container,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -238,6 +238,8 @@ export interface TaskNotesSettings {
 	resetCheckboxesOnRecurrence: boolean; // Reset markdown checkboxes in task body when recurring task completes
 	// Frontmatter link format settings
 	useFrontmatterMarkdownLinks: boolean; // Use markdown links in frontmatter (requires obsidian-frontmatter-markdown-links plugin)
+	// Advanced dependency relationship types (RFC 9253): opt-in authoring of non-Finish-to-Start reltypes
+	enableAdvancedDependencyTypes: boolean;
 	// OAuth Calendar Integration settings
 	googleOAuthClientId: string;
 	googleOAuthClientSecret: string;

--- a/styles/task-modal.css
+++ b/styles/task-modal.css
@@ -1577,6 +1577,13 @@ body.is-mobile .tasknotes-plugin .task-project-item--task-card .task-project-rem
 }
 
 /* Use consistent button system for project remove button */
+.tasknotes-plugin .task-project-item__reltype {
+    flex: 0 0 auto;
+    margin-inline-start: auto;
+    max-width: 12ch;
+    font-size: var(--font-ui-small);
+}
+
 .tasknotes-plugin .task-project-remove {
     background: transparent;
     border: none;

--- a/tests/unit/modals/taskModalReltypeControl.test.ts
+++ b/tests/unit/modals/taskModalReltypeControl.test.ts
@@ -1,0 +1,55 @@
+import {
+	renderDependencyList,
+	type DependencyItem,
+} from "../../../src/modals/taskModalDependencies";
+import type { TaskDependencyRelType } from "../../../src/types";
+
+function unresolvedItem(reltype: TaskDependencyRelType): DependencyItem {
+	return { dependency: { uid: "[[A]]", reltype }, name: "A", unresolved: true };
+}
+
+function baseOptions(listEl: HTMLElement) {
+	return {
+		plugin: {} as never,
+		listEl,
+		items: [unresolvedItem("STARTTOSTART")],
+		linkServices: {} as never,
+		translate: (key: string) => key,
+		onRemove: () => {},
+	};
+}
+
+describe("renderDependencyList reltype control", () => {
+	it("renders a 4-option reltype select seeded from the item and fires onReltypeChange", async () => {
+		const listEl = document.createElement("div");
+		const changes: Array<[number, string]> = [];
+		await renderDependencyList({
+			...baseOptions(listEl),
+			showReltypeControls: true,
+			onReltypeChange: (index, reltype) => changes.push([index, reltype]),
+		});
+
+		const select = listEl.querySelector(
+			"select.task-project-item__reltype"
+		) as HTMLSelectElement | null;
+		expect(select).not.toBeNull();
+		expect(select!.querySelectorAll("option")).toHaveLength(4);
+		expect(select!.value).toBe("STARTTOSTART");
+
+		select!.value = "FINISHTOFINISH";
+		select!.dispatchEvent(new Event("change"));
+		expect(changes).toEqual([[0, "FINISHTOFINISH"]]);
+	});
+
+	it("renders no reltype select when the control is disabled (default behaviour)", async () => {
+		const listEl = document.createElement("div");
+		await renderDependencyList({ ...baseOptions(listEl), showReltypeControls: false });
+		expect(listEl.querySelector("select.task-project-item__reltype")).toBeNull();
+	});
+
+	it("renders no reltype select when the option is omitted", async () => {
+		const listEl = document.createElement("div");
+		await renderDependencyList(baseOptions(listEl));
+		expect(listEl.querySelector("select.task-project-item__reltype")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Third RFC 9253 dependency PR: native authoring of non-Finish-to-Start relationship types from TaskNotes' own task modal, behind an opt-in setting. After this, a user can create Finish→Finish, Start→Start, and Start→Finish dependencies without going through the Gantt or HTTP API.

## What changed

- **Setting** `enableAdvancedDependencyTypes` (default **off**) under a new "Dependencies" group in General settings.
- When enabled, each row of the modal's **Blocked-by** list renders a relationship-type `<select>` (4 RFC types, seeded from the edge), with an `aria-label`.
- Choosing a type mutates the in-memory dependency item. The existing save path already copies `item.dependency` and `dependenciesEqual` already diffs `reltype`, so **no write-path change** is required — the reltype persists to `blockedBy` on save.
- i18n labels + CSS for the selector.

## Scope

- **Blocked-by side only** — the canonical place a dependency edge is authored.
- **Off by default** — existing behaviour (Finish→Start authoring) is unchanged; no new modal chrome unless the user opts in.

## Deferred follow-ups (documented, not in this PR)

- **Structured gap input** (number + unit → ISO-8601) and the **plain-language relationship summary** with `aria-live` — a focused UX follow-up.
- **Blocking-side authoring** — `task.blocking` is paths-only and its write path is add/remove-only, needing disproportionate plumbing.

## Tests

`taskModalReltypeControl` DOM tests: the selector renders 4 options seeded from the edge and fires the change callback with the chosen reltype; no selector renders when the setting is off or omitted. Modal + settings + i18n suites: 353 passing, no regressions (locale key-parity holds — other locales fall back to `en`).
