### PR TITLE
Verify SonarCloud on PR into clean main

### DIFF
--- a/sonar-main-test.txt
+++ b/sonar-main-test.txt
@@ -1,0 +1,1 @@
+Verify SonarCloud analyzes a PR into the clean fork/main. Safe to delete.


### PR DESCRIPTION
Throwaway: does the free plan analyze PRs into main now that main is clean? Delete after.